### PR TITLE
[OpenAPI] Add sorting options to /projects endpoint

### DIFF
--- a/openapi/reference/Default.v1.yaml
+++ b/openapi/reference/Default.v1.yaml
@@ -30,6 +30,11 @@ paths:
           in: query
           description: Sort the data according to a given value. Default is alphabetical.
           name: sort
+        - schema:
+            type: number
+          in: query
+          name: limit
+          description: Amount of projects to return.
     post:
       summary: ''
       operationId: post-projects

--- a/openapi/reference/Default.v1.yaml
+++ b/openapi/reference/Default.v1.yaml
@@ -20,6 +20,16 @@ paths:
                   $ref: ../models/Project.v1.yaml
       operationId: get-projects
       description: Get a list with available projects.
+      parameters:
+        - schema:
+            type: string
+            enum:
+              - recent
+              - popular
+              - alphabetical
+          in: query
+          description: Sort the data according to a given value. Default is alphabetical.
+          name: sort
     post:
       summary: ''
       operationId: post-projects


### PR DESCRIPTION
This adds sorting options to the /projects endpoint
This will be used on the homepage for displaying the most popular projects.

`projects?sort=<popular|recent|alphabetical>`
- Default is *alphabetical*
- **Popular**: Most popular projects first.
- **Recent**: Projects that have been updated recently (issues/pulls added)
- **Alphabetical**: Sort by alphabetical order.