### PR TITLE
[OpenAPI] Make tags global

### DIFF
--- a/openapi/models/Tag.v1.yaml
+++ b/openapi/models/Tag.v1.yaml
@@ -20,9 +20,3 @@ properties:
     type: string
   type:
     type: string
-  project:
-    example: 'http://localhost:3000/projects/1'
-    format: uri
-    type: string
-  projectName:
-    type: string

--- a/openapi/reference/Default.v1.yaml
+++ b/openapi/reference/Default.v1.yaml
@@ -442,17 +442,7 @@ paths:
                   $ref: ../models/Tag.v1.yaml
       operationId: get-tags
       description: Get a list with tags.
-      parameters:
-        - schema:
-            type: boolean
-          in: query
-          name: global
-          description: Should only the global tags (tags not linked to a project) be displayed
-        - schema:
-            type: integer
-          in: query
-          name: projectId
-          description: Id of the project to display all available tags for. Subprojects should also return tags from its parents recursivly.
+      parameters: []
     post:
       summary: ''
       operationId: post-tags


### PR DESCRIPTION
Ik denk als we 2 "types" tags gaan introduceren dat we misschien duplicates gaan krijgen. (eg: ik maak een tag aan in het project Haldis met de naam "Backend" en er is al een globale "Backend" tag).

Daarom zou ik voorstellen om alle tags globaal te maken en gebruik te maken van een zogezegde "Scope". Een tag blijft intern gewoon hetzelfde maar als je in de frontend een tag aanmaakt vanuit een project dan staat er al automatisch de projectnaam voor. (eg: Haldis/Rewrite)

Dit is nog altijd een globale tag, die intern dus ook niet aan een project gekoppeld wordt. Je kan vanuit elk project deze tag selecteren. Maar het geeft wel aan dat die tot dat project behoort. Het is dus puur visueel ipv intern in de backend