### PR TITLE
Add endpoints so we match the spec

### DIFF
--- a/src/clj/g2/routes/branches.clj
+++ b/src/clj/g2/routes/branches.clj
@@ -46,7 +46,19 @@
                            404 {:description "TODO"}}
                :handler   sync-all}}]
    #_["/:issue_id" {:get {:parameters {:path {:issue_id int?}}
-                          :handler    #(get-by-id (get-in % [:path-params :issue_id]))}}]])
+                          :handler    #(get-by-id (get-in % [:path-params :issue_id]))}}]
+   ["/:id"
+    ["/feature" {:delete {:summary "Unfeature the branch with the given id."
+                          :responses {200 {}
+                                      404 {:description "The branch with the specified id does not exist."}}
+                          :parameters {:path {:id int?}}
+                          :handler (response/not-implemented)}
+                 :post {:summary "Feature the branch with the given id."
+                        :responses {200 {}
+                                    404 {:description "The branch with the specified id does not exist."}}
+                        :parameters {:path {:id int?}}
+                        :handler (response/not-implemented)}}]]
+   ])
 
 (defn route-handler-per-project []
   ["/branches"

--- a/src/clj/g2/routes/branches.clj
+++ b/src/clj/g2/routes/branches.clj
@@ -47,18 +47,17 @@
                :handler   sync-all}}]
    #_["/:issue_id" {:get {:parameters {:path {:issue_id int?}}
                           :handler    #(get-by-id (get-in % [:path-params :issue_id]))}}]
-   ["/:id"
-    ["/feature" {:delete {:summary "Unfeature the branch with the given id."
+   ["/:id/feature" {:delete {:summary "Unfeature the branch with the given id."
                           :responses {200 {}
                                       404 {:description "The branch with the specified id does not exist."}}
                           :parameters {:path {:id int?}}
-                          :handler (response/not-implemented)}
+                          :handler #(response/not-implemented)}
                  :post {:summary "Feature the branch with the given id."
                         :responses {200 {}
                                     404 {:description "The branch with the specified id does not exist."}}
                         :parameters {:path {:id int?}}
-                        :handler (response/not-implemented)}}]]
-   ])
+                        :handler #(response/not-implemented)}}]]
+   )
 
 (defn route-handler-per-project []
   ["/branches"

--- a/src/clj/g2/routes/home.clj
+++ b/src/clj/g2/routes/home.clj
@@ -16,7 +16,8 @@
             [clojure.pprint :refer [pprint]]
             [clojure.string :as string]
             [reitit.swagger :as swagger]
-            [reitit.swagger-ui :as swagger-ui]))
+            [reitit.swagger-ui :as swagger-ui]
+            [g2.routes.pulls :as pulls]))
 
 (defn home-page [request]
   (let [repo-providers (db/get-all-repo-providers)]
@@ -45,6 +46,7 @@
    ; not included in the newer spec
    #_(labels/route-handler-global)
    (branches/route-handler-global)
+   (pulls/route-handler-global)
    ["/repo-providers"
     {:get {:summary "Get the list of repository providers configured (like for ex. github or gitlab)"
            :handler (fn [_] (response/ok (db/get-all-repo-providers)))}}]

--- a/src/clj/g2/routes/issues.clj
+++ b/src/clj/g2/routes/issues.clj
@@ -46,7 +46,17 @@
                            404 {:description "TODO"}}
                :handler   sync-all}}]
    #_["/:issue_id" {:get {:parameters {:path {:issue_id int?}}
-                          :handler    #(get-by-id (get-in % [:path-params :issue_id]))}}]])
+                          :handler    #(get-by-id (get-in % [:path-params :issue_id]))}}]
+    ["/:id/feature" {:delete {:summary "Unfeature the issue with the given id."
+                          :responses {200 {}
+                                      404 {:description "The issue with the specified id does not exist."}}
+                          :parameters {:path {:id int?}}
+                          :handler #(response/not-implemented)}
+                 :post {:summary "Feature the issue with the given id."
+                        :responses {200 {}
+                                    404 {:description "The issue with the specified id does not exist."}}
+                        :parameters {:path {:id int?}}
+                        :handler #(response/not-implemented)}}]])
 
 (defn route-handler-per-project []
   ["/issues"

--- a/src/clj/g2/routes/projects.clj
+++ b/src/clj/g2/routes/projects.clj
@@ -153,6 +153,5 @@
     (repos/route-handler-per-project)
     (issues/route-handler-per-project)
     (pulls/route-handler-per-project)
-    (labels/route-handler-per-project)
     (branches/route-handler-per-project)
     (tags/tags-operations-route-handler (entity/project) [])]])

--- a/src/clj/g2/routes/projects.clj
+++ b/src/clj/g2/routes/projects.clj
@@ -140,6 +140,16 @@
                                      404 {:description "The project with the specified id does not exist."}}
                         :parameters {:path {:id int?}}
                         :handler    #(project-features [:path-params :id])}}]
+    ["/feature" {:delete {:summary "Unfeature the project with the given id."
+                           :responses {200 {}
+                                       404 {:description "The project with the specified id does not exist."}}
+                           :parameters {:path {:id int?}}
+                           :handler (response/not-implemented)}
+                  :post {:summary "Feature the project with the given id."
+                         :responses {200 {}
+                                     404 {:description "The project with the specified id does not exist."}}
+                         :parameters {:path {:id int?}}
+                         :handler (response/not-implemented)}}]
     (repos/route-handler-per-project)
     (issues/route-handler-per-project)
     (pulls/route-handler-per-project)

--- a/src/clj/g2/routes/pulls.clj
+++ b/src/clj/g2/routes/pulls.clj
@@ -20,8 +20,7 @@
   ["/pulls"
    {:swagger {:tags ["pulls"]}}
    (tags/tags-route-handler (entity/pull) [])
-   ["/:id"
-    ["/feature" {:delete {:summary "Unfeature the pull request with the given id."
+   ["/:id/feature" {:delete {:summary "Unfeature the pull request with the given id."
                           :responses {200 {}
                                       404 {:description "The pull request with the specified id does not exist."}}
                           :parameters {:path {:id int?}}
@@ -31,7 +30,7 @@
                                     404 {:description "The pull request with the specified id does not exist."}}
                         :parameters {:path {:id int?}}
                         :handler #(response/not-implemented)}}]]
-   ])
+   )
 
 (defn route-handler-per-project []
   ["/pulls" {:get {:summary    "Get the pulls of a project"

--- a/src/clj/g2/routes/pulls.clj
+++ b/src/clj/g2/routes/pulls.clj
@@ -1,7 +1,8 @@
 (ns g2.routes.pulls
   (:require [ring.util.http-response :as response]
             [g2.db.core :refer [*db*] :as db]
-            [g2.routes.tags :as tags]))
+            [g2.routes.tags :as tags]
+            [g2.utils.entity :as entity]))
 
 (defn get-pull [id]
   (response/ok {}))
@@ -14,6 +15,23 @@
 #_(defn route-handler-global []
   ["/pulls"
    (tags/tags-route-handler "Pull request" db/get-pulls)])
+
+(defn route-handler-global []
+  ["/pulls"
+   {:swagger {:tags ["pulls"]}}
+   (tags/tags-route-handler (entity/pull) [])
+   ["/:id"
+    ["/feature" {:delete {:summary "Unfeature the pull request with the given id."
+                          :responses {200 {}
+                                      404 {:description "The pull request with the specified id does not exist."}}
+                          :parameters {:path {:id int?}}
+                          :handler #(response/not-implemented)}
+                 :post {:summary "Feature the pull request with the given id."
+                        :responses {200 {}
+                                    404 {:description "The pull request with the specified id does not exist."}}
+                        :parameters {:path {:id int?}}
+                        :handler #(response/not-implemented)}}]]
+   ])
 
 (defn route-handler-per-project []
   ["/pulls" {:get {:summary    "Get the pulls of a project"

--- a/src/clj/g2/routes/repos.clj
+++ b/src/clj/g2/routes/repos.clj
@@ -50,9 +50,13 @@
   ["/repositories"
    {:swagger {:tags ["repository"]}}
    ["" {:get {:summary "Get the list of code repositories in our backend."
+              :responses {200 {}}
               :handler repos-get}}]
    ["/sync" {:swagger {:tags ["sync"]}
              :post    {:summary "Synchronise the data from all repositories with our database."
+                       :responses {200 {:description "TODO"}
+                                   403 {:description "TODO"}
+                                   404 {:description "TODO"}}
                        :handler (fn [_] (git/sync-repositories) (response/ok))}}]
    (tags/tags-route-handler (entity/repository) [])
    #_["/branches"

--- a/src/clj/g2/routes/repos.clj
+++ b/src/clj/g2/routes/repos.clj
@@ -60,7 +60,19 @@
       ["/:branch_id"]]
    #_["/labels"
       [""]
-      ["/:label_id"]]])
+      ["/:label_id"]]
+   [":repo_id/projects/:project_id" {:delete {:summary "Unlink a given project id to a given repository"
+                                              :responses {200 {}
+                                                          404 {:description "The repository or project with the specified id does not exist."}}
+                                              :parameters {:path {:repo_id int?
+                                                                  :project_id int?}}
+                                              :handler #(response/not-implemented)}
+                                     :post {:summary "Link a given project id to a given repository"
+                                            :responses {200 {}
+                                                        404 {:description "The repository or project with the specified id does not exist."}}
+                                            :parameters {:path {:repo_id int?
+                                                                :project_id int?}}
+                                            :handler #(response/not-implemented)}}]])
 
 (defn route-handler-per-project []
   ["/repositories"

--- a/src/clj/g2/utils/entity.clj
+++ b/src/clj/g2/utils/entity.clj
@@ -21,5 +21,8 @@
 (defn branch []
   "branches")
 
+(defn pull []
+  "pull request")
+
 #_(defn pull []
     (gen-entity "Pull" db/get-pull db/get-pulls))


### PR DESCRIPTION
There are 2 methods on 1 endpoint that aren't in the spec, but we have anyway:
- POST /repositories/{id}/tags/{tag}
- DELETE /repositories/{id}/tags/{tag}

otherwise we should match the spec completely