### PR TITLE
Filter GitHub repos and save repo_type in db

### DIFF
--- a/resources/sql/queries.sql
+++ b/resources/sql/queries.sql
@@ -193,8 +193,8 @@ UNION
 
 -- :name create-repo! :insert :raw
 INSERT INTO repos
-    (tag_id, git_id, name, description, url)
-VALUES (:tag_id, :git_id, :name, :description, :url);
+    (tag_id, git_id, repo_type, name, description, url)
+VALUES (:tag_id, :git_id, :repo_type, :name, :description, :url);
 
 -- :name get-repos :? :*
 SELECT repos.tag_id                                as id,

--- a/src/clj/g2/git/github.clj
+++ b/src/clj/g2/git/github.clj
@@ -126,7 +126,7 @@
                               :git_id                       ; local and remote shared unique identifier
                               nil
                               (fn [] (filter #(= (get % :repo_type) "github") (db/get-tags {:table (entity/repository)})))
-                              #(db/create-repo! (assoc % :tag_id (entity/generate-tag)))
+                              #(db/create-repo! (assoc % :tag_id (entity/generate-tag) :repo_type "github"))
                               db/update-repo!)))
 
 (defn sync-labels

--- a/src/clj/g2/git/github.clj
+++ b/src/clj/g2/git/github.clj
@@ -125,9 +125,7 @@
                                :html_url    :url}
                               :git_id                       ; local and remote shared unique identifier
                               nil
-                              (do (doall (map println (db/get-tags {:table (entity/repository)})))
-                                  (fn [] (filter (fn [repo] (= (get repo :repo_type) "github")) (db/get-tags {:table (entity/repository)})))
-                                  )
+                              (fn [] (filter #(= (get % :repo_type) "github") (db/get-tags {:table (entity/repository)})))
                               #(db/create-repo! (assoc % :tag_id (entity/generate-tag)))
                               db/update-repo!)))
 

--- a/src/clj/g2/git/github.clj
+++ b/src/clj/g2/git/github.clj
@@ -125,7 +125,9 @@
                                :html_url    :url}
                               :git_id                       ; local and remote shared unique identifier
                               nil
-                              db/get-repos                  ;; TODO filter to only fetch github repos
+                              (do (doall (map println (db/get-tags {:table (entity/repository)})))
+                                  (fn [] (filter (fn [repo] (= (get repo :repo_type) "github")) (db/get-tags {:table (entity/repository)})))
+                                  )
                               #(db/create-repo! (assoc % :tag_id (entity/generate-tag)))
                               db/update-repo!)))
 


### PR DESCRIPTION
The repositories are getting filtered on the repo_type.
Also fixed that the repo_type is getting saved in the database.
If the repo_type is null in the database the synchronization of the repositories will fail. 

closes #75 